### PR TITLE
Fix warnings about positional parameter mismatch

### DIFF
--- a/behavioral/interpreter.cr
+++ b/behavioral/interpreter.cr
@@ -60,7 +60,7 @@ abstract class Evaluator
 end
 
 class TerminalExpression < Evaluator
-  def evaluate(_press)
+  def evaluate(press)
     if special_move
       context.moves << special_move.as(Move)
     else

--- a/behavioral/mediator.cr
+++ b/behavioral/mediator.cr
@@ -52,12 +52,12 @@ class Match < MediatorBase
     end
   end
 
-  def perform_move(move, fighter)
-    if can_perform_move?(move, fighter)
-      if (fighter == player1)
-        player2.as(Fighter).receive(move, fighter)
-      elsif (fighter == player2)
-        player1.as(Fighter).receive(move, fighter)
+  def perform_move(move, performer)
+    if can_perform_move?(move, performer)
+      if (performer == player1)
+        player2.as(Fighter).receive(move, performer)
+      elsif (performer == player2)
+        player1.as(Fighter).receive(move, performer)
       end
     else
       puts "Ignoring move"

--- a/behavioral/strategy.cr
+++ b/behavioral/strategy.cr
@@ -35,19 +35,19 @@ abstract class FightStrategy
 end
 
 class Puncher < FightStrategy
-  def attack(ft, op)
-    puts "#{ft.name} attacks #{op.name} with 1 punch."
-    op.damage(HITS[:punch])
+  def attack(fighter, opponent)
+    puts "#{fighter.name} attacks #{opponent.name} with 1 punch."
+    opponent.damage(HITS[:punch])
   end
 end
 
 class Combo < FightStrategy
-  def attack(ft, op)
-    puts "#{ft.name} attacks #{op.name} with 2 kicks and 1 punch."
+  def attack(fighter, opponent)
+    puts "#{fighter.name} attacks #{opponent.name} with 2 kicks and 1 punch."
 
-    op.damage(HITS[:kick])
-    op.damage(HITS[:kick])
-    op.damage(HITS[:punch])
+    opponent.damage(HITS[:kick])
+    opponent.damage(HITS[:kick])
+    opponent.damage(HITS[:punch])
   end
 end
 

--- a/structural/flyweight.cr
+++ b/structural/flyweight.cr
@@ -23,8 +23,7 @@ class Tree < FlyweightTree
     @pos = {0, 0}
   end
 
-  def draw_at(_pos : Position)
-    pos = _pos
+  def draw_at(pos : Position)
     puts "Drawing #{@species} at #{pos}"
   end
 end


### PR DESCRIPTION
Implementations of abstract methods should use the same parameter names as the abstract def.

This patch fixes that and removes the respective warnings:
```
In structural/flyweight.cr:26:15

 26 | def draw_at(_pos : Position)
                  ^---
Warning: positional parameter '_pos' corresponds to parameter 'pos' of the overridden method FlyweightTree#draw_at(pos : Position), which has a different name and may affect named argument passing

A total of 1 warnings were found.
```

```
In behavioral/interpreter.cr:63:16

 63 | def evaluate(_press)
                   ^-----
Warning: positional parameter '_press' corresponds to parameter 'press' of the overridden method Evaluator#evaluate(press), which has a different name and may affect named argument passing

A total of 1 warnings were found.
```

```
In behavioral/mediator.cr:55:26

 55 | def perform_move(move, fighter)
                             ^------
Warning: positional parameter 'fighter' corresponds to parameter 'performer' of the overridden method MediatorBase#perform_move(move, performer), which has a different name and may affect named argument passing

A total of 1 warnings were found.
```

```
In behavioral/strategy.cr:38:14

 38 | def attack(ft, op)
                 ^-
Warning: positional parameter 'ft' corresponds to parameter 'fighter' of the overridden method FightStrategy#attack(fighter, opponent), which has a different name and may affect named argument passing

In behavioral/strategy.cr:38:18

 38 | def attack(ft, op)
                     ^-
Warning: positional parameter 'op' corresponds to parameter 'opponent' of the overridden method FightStrategy#attack(fighter, opponent), which has a different name and may affect named argument passing

In behavioral/strategy.cr:45:14

 45 | def attack(ft, op)
                 ^-
Warning: positional parameter 'ft' corresponds to parameter 'fighter' of the overridden method FightStrategy#attack(fighter, opponent), which has a different name and may affect named argument passing

In behavioral/strategy.cr:45:18

 45 | def attack(ft, op)
                     ^-
Warning: positional parameter 'op' corresponds to parameter 'opponent' of the overridden method FightStrategy#attack(fighter, opponent), which has a different name and may affect named argument passing

A total of 4 warnings were found.
```